### PR TITLE
Revert memory search override logic

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,4 @@
+# Future Tasks
+
+- [ ] Allow configurable max memories and relevance threshold when searching user memories.
+

--- a/plugin/lib/memory-enhanced-reading.js
+++ b/plugin/lib/memory-enhanced-reading.js
@@ -197,6 +197,9 @@ class MemoryEnhancedReading {
 
     /**
      * Search for memories relevant to the current page content
+     *
+     * TODO: support per-call overrides for `maxMemories` and
+     * `relevanceThreshold` once requirements are defined.
      */
     async searchRelevantMemories(content) {
         try {


### PR DESCRIPTION
## Summary
- revert the previous change that added optional override parameters
- add TODO comment for future per-call search options
- add a TODO.md file to track the feature request

## Testing
- `node -c plugin/lib/memory-enhanced-reading.js`


------
https://chatgpt.com/codex/tasks/task_e_685b97007648832b8426ab6edec57821